### PR TITLE
solve compiler warning -Wlogical-not-parentheses when using -Werror

### DIFF
--- a/Source/AsyncPackageStreamer/Private/AssetStreamer.cpp
+++ b/Source/AsyncPackageStreamer/Private/AssetStreamer.cpp
@@ -62,7 +62,7 @@ bool FAssetStreamer::StreamPackage(const FString& PakFileName, IAssetStreamerLis
     Listener = NULL;
 
     const bool bRemote = (DesiredMode == EAssetStreamingMode::Remote);
-    if (!(bRemote && UseRemote(CmdLine) || !bRemote && UseLocal(CmdLine)))
+    if (!((bRemote && UseRemote(CmdLine)) || (!bRemote && UseLocal(CmdLine))))
     {
         Unlock();
         return false;


### PR DESCRIPTION
This allows linux to build the plugin without errors.  Linux build rules included a flag that marks this warning as an error.
